### PR TITLE
`ngx-flex-limitter@2.0.1`: Build fix

### DIFF
--- a/projects/ngx-flex-limitter/CHANGELOG.md
+++ b/projects/ngx-flex-limitter/CHANGELOG.md
@@ -1,0 +1,15 @@
+<!-- markdownlint-disable MD001 -->
+
+# Releases
+
+### 2.0.1
+
+Fix import issue due to an incorrect build
+
+## 2.0.0
+
+Update to Angular 14
+
+## 1.0.0
+
+Initial release

--- a/projects/ngx-flex-limitter/package.json
+++ b/projects/ngx-flex-limitter/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@lesfabricants/ngx-flex-limitter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A library for limiting the number of lines in a flex container.",
   "repository": {
     "type": "git",
     "url": "https://github.com/Passiverecords/libraries.git",
     "directory": "projects/ngx-flex-limitter"
   },
-  "readme": "https://github.com/Passiverecords/libraries/tree/develop/projects/ngx-flex-limitter/README.md",
+  "homepage": "https://github.com/Passiverecords/libraries/tree/develop/projects/ngx-flex-limitter/README.md",
   "peerDependencies": {
     "@angular/common": "^14.0.0",
     "@angular/core": "^14.0.0"


### PR DESCRIPTION
The version pushed online was the dev version, not the properly built version 😔